### PR TITLE
fix: noop observability crashing because of returned empty impl struct

### DIFF
--- a/observability/noop_observability.go
+++ b/observability/noop_observability.go
@@ -52,8 +52,8 @@ func (n *noopObservability) Metrics() *Metrics {
 func (n *noopObservability) SetupGinMiddleware(router *gin.Engine, opts ...MetricMiddlewareOpt) {
 }
 
-func (n *noopObservability) WithSpanKind(spanKind trace.SpanKind) *Impl {
-	return &Impl{}
+func (n *noopObservability) WithSpanKind(spanKind trace.SpanKind) Observability {
+	return n
 }
 
 func (n *noopObservability) IsTracingEnabled() bool {

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -52,7 +52,7 @@ type Observability interface {
 	Log() *otelzap.Logger
 	Metrics() *Metrics
 	SetupGinMiddleware(router *gin.Engine, opts ...MetricMiddlewareOpt)
-	WithSpanKind(spanKind trace.SpanKind) *Impl
+	WithSpanKind(spanKind trace.SpanKind) Observability
 	IsTracingEnabled() bool
 	IsProfilingEnabled() bool
 	AreMetricsEnabled() bool
@@ -237,7 +237,7 @@ func (obs *Impl) clone() *Impl {
 }
 
 // WithSpanKind returns a copy of the observability instance with the given span type
-func (obs *Impl) WithSpanKind(spanKind trace.SpanKind) *Impl {
+func (obs *Impl) WithSpanKind(spanKind trace.SpanKind) Observability {
 	o := obs.clone()
 	o.spanKind = spanKind
 	return o


### PR DESCRIPTION
## Proposed changes

- Fixed test crashes because noop observability returned an empty Impl struct (panicked)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...